### PR TITLE
feat: show inline validation errors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -218,3 +218,7 @@ h3{font-size:clamp(18px,2.2vw,22px);line-height:1.25}
 .footer a{color:#cfd3da}
 .footer small{color:#8e939a}
 @media(max-width:900px){.footer .cols{grid-template-columns:1fr}}
+
+/* Form validation */
+.invalid{border-color:#ff6b6b!important}
+.error{display:block;color:#ff6b6b;font-size:14px;margin-top:4px}

--- a/js/main.js
+++ b/js/main.js
@@ -78,17 +78,50 @@
 
   // Basic client side form validation
   document.querySelectorAll('form[data-validate]')?.forEach(form => {
+    const required = form.querySelectorAll('[required]');
+
+    const showError = el => {
+      const container = el.closest('.field') || el.parentElement;
+      let msg = container.querySelector('.error');
+      if (!msg) {
+        msg = document.createElement('span');
+        msg.className = 'error';
+        msg.setAttribute('aria-live', 'polite');
+        msg.textContent = 'This field is required.';
+        container.appendChild(msg);
+      }
+      el.classList.add('invalid');
+    };
+
+    const clearError = el => {
+      const container = el.closest('.field') || el.parentElement;
+      const msg = container.querySelector('.error');
+      if (msg) msg.remove();
+      el.classList.remove('invalid');
+    };
+
+    required.forEach(el => {
+      el.addEventListener('input', () => {
+        if (el.value.trim()) clearError(el);
+      });
+    });
+
     form.addEventListener('submit', e => {
-      const required = form.querySelectorAll('[required]');
       let ok = true;
       required.forEach(el => {
-        if (!el.value.trim()) { el.classList.add('invalid'); ok = false; }
-        else { el.classList.remove('invalid'); }
+        if (!el.value.trim()) {
+          if (ok) el.focus();
+          showError(el);
+          ok = false;
+        } else {
+          clearError(el);
+        }
       });
-      if (!ok) {
-        e.preventDefault();
-        alert('Please complete required fields.');
-      }
+      if (!ok) e.preventDefault();
+    });
+
+    form.addEventListener('reset', () => {
+      required.forEach(clearError);
     });
   });
 })();


### PR DESCRIPTION
## Summary
- replace alert validation with inline error messages
- style invalid fields and error text
- clear validation errors as form fields are corrected

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea3403450832db7b01debaef6299c